### PR TITLE
feat: open stdin & allocate tty on dev services

### DIFF
--- a/tutorforum/patches/local-docker-compose-dev-services
+++ b/tutorforum/patches/local-docker-compose-dev-services
@@ -1,0 +1,3 @@
+forum:
+  stdin_open: true
+  tty: true


### PR DESCRIPTION
This ensures that services started with `tutor dev start`
are as capable for breakpoint debugging, et al, as services
started with `tutor dev runserver` are. We plan to remove
`tutor dev runserver`.

Blocks https://github.com/overhangio/tutor/pull/644