### PR TITLE
feat: add COMPOSE_MOUNTS for cs_comments_service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,9 @@ To debug the comments service, you are encouraged to mount the cs_comments_servi
 
     tutor dev start --mount /path/to/cs_comments_service
 
-Feel free to add breakpoints (``import pdb; pdb.set_trace()``) anywhere in your source code to debug your application.
+Once a local repository is mounted in the image, you will have to install all gems (ruby dependencies)::
+
+    bundle install
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,15 @@ Configuration
 - ``FORUM_PORT`` (default: ``"4567""``)
 - ``FORUM_API_KEY`` (default: ``"forumapikey"``)
 
+Debugging
+---------
+
+To debug the comments service, you are encouraged to mount the cs_comments_service repo from the host in the development container:
+
+    tutor dev start --mount /path/to/cs_comments_service
+
+Feel free to add breakpoints (``import pdb; pdb.set_trace()``) anywhere in your source code to debug your application.
+
 License
 -------
 

--- a/tutorforum/plugin.py
+++ b/tutorforum/plugin.py
@@ -37,6 +37,20 @@ tutor_hooks.Filters.IMAGES_PUSH.add_item((
     "{{ FORUM_DOCKER_IMAGE }}",
 ))
 
+@tutor_hooks.Filters.COMPOSE_MOUNTS.add()
+def _mount_cs_comments_service(volumes, name):
+    """
+    When mounting cs_comments_service with `--mount=/path/to/cs_comments_service`,
+    bind-mount the host repo in the forum container.
+    """
+    if name == "cs_comments_service":
+        path = "/app/cs_comments_service"
+        volumes += [
+            ("forum", path),
+            ("forum-job", path),
+        ]
+    return volumes
+
 # Add the "templates" folder as a template root
 tutor_hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(
     pkg_resources.resource_filename("tutorforum", "templates")


### PR DESCRIPTION
Part of https://github.com/overhangio/2u-tutor-adoption/issues/26

In order to remove `runserver`, the following must be done for all official tutor plugins:

- [X] Ensure that the plugin is ported to the V1 API
- [ ] Ensure that the plugin hooks into the COMPOSE_MOUNTS filter in order to automatically bind-mount folders as appropriate.
- [X] Replace any references to runserver with start
- [X] Replace any references to the --volume option with an equivalent usage of the --mount option.

Within this repo, there was only one incomplete task: 'Ensure that the plugin hooks into the `COMPOSE_MOUNTS` filter in order to automatically bind-mount folders as appropriate.'. This task is solved with this PR.

A `COMPOSE_MOUNTS` function has been added to easily mount
`cs_comments_service` to `/app/cs_comments_service`

It was tested by installing the plugin and mounting a local `cs_comments_service` via `tutor dev run forum --mount=/path/to/cs_comments_service bash`, and checking that files changed or created within the container's bash shell could be found in the local `cs_comments_service` directory, and vice versa.