### PR TITLE
docs: change quickstart to launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Usage
 ::
 
     tutor plugins enable forum
-    tutor local quickstart
+    tutor local launch 
 
 Configuration
 -------------


### PR DESCRIPTION
This is due to renaming quickstart to launch in tutor.
See https://github.com/overhangio/tutor/pull/724