### PR TITLE
feat: more efficient Docker build

### DIFF
--- a/tutorforum/templates/forum/build/forum/Dockerfile
+++ b/tutorforum/templates/forum/build/forum/Dockerfile
@@ -1,43 +1,39 @@
-FROM docker.io/ruby:3.0.4-slim-bullseye
+# https://hub.docker.com/_/ruby/tags
+FROM docker.io/ruby:3.0.5-slim-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
   apt upgrade -y && \
-  apt install -y git wget curl autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev
+  apt install -y git wget curl autoconf bison build-essential libffi-dev libgdbm-dev libncurses5-dev libssl-dev libyaml-dev libreadline6-dev zlib1g-dev
 
 # Install dockerize to wait for mongodb/elasticsearch availability
-ARG DOCKERIZE_VERSION=v0.6.1
-RUN wget -O /tmp/dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf /tmp/dockerize.tar.gz \
-    && rm /tmp/dockerize.tar.gz
+# https://hub.docker.com/r/powerman/dockerize/tags
+COPY --from=docker.io/powerman/dockerize:0.19.0 /usr/local/bin/dockerize /usr/local/bin/dockerize
 
 # Create unprivileged "app" user
-RUN useradd --home-dir /app --create-home --shell /bin/bash --uid 1000 app
-
-# Copy custom scripts
-COPY ./bin /app/bin
-RUN chmod a+x /app/bin/*
-ENV PATH :${PATH}
-
 # From then on, run as unprivileged app user
+RUN useradd --home-dir /app --create-home --shell /bin/bash --uid 1000 app
 USER app
 
 # Install rake and bundler
-ENV PATH "/app/bin:/app/.gem/ruby/3.0.4/bin:$PATH"
+ENV PATH "/app/.gem/ruby/3.0.4/bin:$PATH"
 RUN gem install --user-install bundler --version 1.17.3
 RUN gem install --user-install rake --version 13.0.6
 
-# Install forum
-ENV BUNDLE_GEMFILE Gemfile3
-
+# Clone repo
 ARG FORUM_REPOSITORY={{ FORUM_REPOSITORY }}
 ARG FORUM_REPOSITORY_VERSION={{ FORUM_REPOSITORY_VERSION }}
 RUN git clone $FORUM_REPOSITORY --branch $FORUM_REPOSITORY_VERSION --depth 1 /app/cs_comments_service
 
+# Install ruby requirements
 WORKDIR /app/cs_comments_service
+ENV BUNDLE_GEMFILE Gemfile3
 RUN bundle install --deployment
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+# Copy entrypoint
+COPY --chown=app:app ./bin/docker-entrypoint.sh /app/bin/docker-entrypoint.sh
+RUN chmod a+x /app/bin/docker-entrypoint.sh
+ENTRYPOINT ["/app/bin/docker-entrypoint.sh"]
 
 ENV SINATRA_ENV staging
 ENV NEW_RELIC_ENABLE false


### PR DESCRIPTION
Previously, changes to the entrypoint script were causing full re-build of the forum image. To address this, we move the COPY statement to the bottom of the Dockerfile.

In addition, we take this opportunity to upgrade the ruby base image (3.0.4 -> 3.05) and the dockerize binary.

Close #13.