### PR TITLE
chore: clean up the README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,25 +1,30 @@
 Forum plugin for `Tutor <https://docs.tutor.edly.io>`__
-============================================================
+=======================================================
 
-This plugin adds `discussion forums <https://github.com/openedx/cs_comments_service>`__ to your `Open edX <https://openedx.org/>`__ platform, such that students can have conversations about the courses they are following right in your LMS.
+This plugin adds `discussion forums`_ to your `Open edX`_ platform, such that students
+can have conversations about the courses they are following right in your LMS.
 
 .. image:: https://overhang.io/static/catalog/screenshots/forum.png
   :alt: Forum screenshot
 
+
+.. _discussion forums: https://github.com/openedx/cs_comments_service
+.. _Open edX: https://openedx.org/
+
 Installation
 ------------
 
-::
+.. code-block:: bash
 
     tutor plugins install forum
 
 Usage
 -----
 
-::
+.. code-block:: bash
 
     tutor plugins enable forum
-    tutor local launch
+    tutor dev|local|k8s launch
 
 Configuration
 -------------
@@ -40,8 +45,8 @@ Customising Environment Variables
 To add, or modify environment variables that are supplied to the forum service,
 you can use the ``FORUM_ENV`` hook.
 
-To add or modify a environment variable, update the corresponding entry in the
-``FORUM_ENV`` dict as follows:
+To add or modify an environment variable, update the corresponding entry in the
+``FORUM_ENV`` dictionary as follows:
 
 .. code-block:: python
 
@@ -56,32 +61,43 @@ If the environment variable already exists, it will be overridden, otherwise it
 will be added. Note that if multiple plugins override the same value, the last
 override will apply.
 
-It is posible to use templates when setting the above values.
+It is possible to use templates when setting the above values.
 
 
-Caveats for the `mongodb+srv://` syntax
+Caveats for the ``mongodb+srv://`` syntax
 ---------------------------------------
 
-While the newer `mongodb+srv:// <https://www.mongodb.com/developer/products/mongodb/srv-connection-strings/>`__ syntax for the `MONGODB_HOST` is supported, there are some tradeoffs:
+While the newer `mongodb+srv:// <https://www.mongodb.com/developer/products/mongodb/srv-connection-strings/>`__ syntax
+for the ``MONGODB_HOST`` is supported, there are some tradeoffs:
 
 - Query parameters in the URL will be ignored by the forum. Please use the provided configuration options instead.
-- The username and password should form part of the URL in the format `mongodb+srv://username:password@host/`.
+- The username and password should form part of the URL in the format ``mongodb+srv://username:password@host/``.
 
 Debugging
 ---------
 
-To debug the comments service, you are encouraged to mount the cs_comments_service repo from the host in the development container:
+To debug the comments service, you are encouraged to mount the ``cs_comments_service`` repo from the host in the development container:
 
-    tutor dev start --mount /path/to/cs_comments_service
+.. code-block:: bash
 
-Once a local repository is mounted in the image, you will have to install all gems (ruby dependencies)::
+    tutor mounts add /path/to/cs_comments_service
+    tutor dev start
+
+Once a local repository is mounted in the image, you will have to install all `gems`_ (ruby dependencies):
+
+.. code-block:: bash
 
     bundle install
+
+.. _gems: https://guides.rubygems.org/what-is-a-gem/
 
 Troubleshooting
 ---------------
 
-This Tutor plugin is maintained by Ghassan Maslamani from `Abstract-Technology <https://abstract-technology.de>`__. Community support is available from the official `Open edX forum <https://discuss.openedx.org>`__. Do you need help with this plugin? See the `troubleshooting <https://docs.tutor.edly.io/troubleshooting.html>`__ section from the Tutor documentation.
+This Tutor plugin is maintained by Ghassan Maslamani from `Abstract-Technology <https://abstract-technology.de>`__.
+Community support is available from the official `Open edX forum <https://discuss.openedx.org>`__.
+Do you need help with this plugin? See the `troubleshooting <https://docs.tutor.edly.io/troubleshooting.html>`__ section
+from the Tutor documentation.
 
 License
 -------


### PR DESCRIPTION
This commit
- Added more readability to the document
- Fixed typos
- Added code-blocks

@ghassanmas @regisb 
I changed the `--mount` option to `tutor mounts add` in the readme. is that ok?