### PR TITLE
refactor: ignore TLS certificates on dockerize wait

### DIFF
--- a/tutorforum/templates/forum/build/forum/bin/docker-entrypoint.sh
+++ b/tutorforum/templates/forum/build/forum/bin/docker-entrypoint.sh
@@ -14,6 +14,6 @@ else
     WAIT_MONGODB="-wait tcp://$MONGODB_HOST:$MONGODB_PORT"
 fi
 
-dockerize $WAIT_MONGODB -wait $SEARCH_SERVER -wait-retry-interval 5s -timeout 600s
+dockerize $WAIT_MONGODB -wait $SEARCH_SERVER -wait-retry-interval 5s -timeout 600s -skip-tls-verify
 
 exec "$@"


### PR DESCRIPTION
This PR adds an extra parameter to `dockerize` to skip TLS certificate validation. Since the validation is already done in Forum, this is not a harmful step, but a "quick-fix" for [custom CA certificates issues](https://github.com/overhangio/tutor-forum/pull/35) until `dockerize` is [removed](https://github.com/overhangio/tutor-forum/pull/40).

PS: This change has been discussed with @regisb.