### PR TITLE
fix: when source code is not mounted resolves #45

### DIFF
--- a/changelog.d/20240828_131853_ghassan.maslamani_resolve_45.md
+++ b/changelog.d/20240828_131853_ghassan.maslamani_resolve_45.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix when src is not mounted

--- a/tutorforum/patches/local-docker-compose-jobs-services
+++ b/tutorforum/patches/local-docker-compose-jobs-services
@@ -2,8 +2,10 @@ forum-job:
   image: {{ FORUM_DOCKER_IMAGE }}
   environment:
     {{ patch("forum-local-env")|indent(4) }}
+{%- if iter_mounts(MOUNTS, "forum")|first is defined %}
   volumes:
     {%- for mount in iter_mounts(MOUNTS, "forum") %}
     - {{ mount }}
     {%- endfor %}
+{%- endif %}
   depends_on: {{ [("elasticsearch", RUN_ELASTICSEARCH), ("mongodb", RUN_MONGODB)]|list_if }}

--- a/tutorforum/patches/local-docker-compose-services
+++ b/tutorforum/patches/local-docker-compose-services
@@ -2,9 +2,11 @@ forum:
   image: {{ FORUM_DOCKER_IMAGE }}
   environment:
     {{ patch("forum-local-env")|indent(4) }}
+{%- if iter_mounts(MOUNTS, "forum")|first is defined   %}
   volumes:
     {%- for mount in iter_mounts(MOUNTS, "forum") %}
     - {{ mount }}
     {%- endfor %}
+{%- endif %}
   restart: unless-stopped
   depends_on: {{ [("elasticsearch", RUN_ELASTICSEARCH), ("mongodb", RUN_MONGODB)]|list_if }}


### PR DESCRIPTION
Add a condition to test if mounted list does include entries, since empty `volume` defintion is not accepted in Docker compose syntax