### PR TITLE
fix: merging edly/forum_v2 branch to sumac.master

### DIFF
--- a/tutorforum/plugin.py
+++ b/tutorforum/plugin.py
@@ -28,7 +28,7 @@ tutor_hooks.Filters.ENV_PATCHES.add_items(
             """
 RUN git remote add edly https://github.com/edly-io/edx-platform \
     && git fetch edly edly/forumv2 \
-    && git merge edly/edly/forumv2""",
+    && git merge --allow-unrelated-histories edly/edly/forumv2""",
         ),
         # Enable forum feature
         (


### PR DESCRIPTION
- This Commit will fix the merging due to error: `fatal: refusing to merge unrelated histories`. As soon as the edly/forumv2 branch is merged in master and new release for sumac is launched on upstream we can remove these extra patches in dockerfle.