### PR TITLE
chore: remove platform changes patch

### DIFF
--- a/tutorforum/plugin.py
+++ b/tutorforum/plugin.py
@@ -18,27 +18,15 @@ config = {
 # Auto-mount forum repository
 tutor_hooks.Filters.MOUNTED_DIRECTORIES.add_item(("openedx", "forum"))
 
-tutor_hooks.Filters.ENV_PATCHES.add_items(
-    [
-        # Patch edx-platform
-        # https://github.com/openedx/edx-platform/pull/35671
-        # TODO after this PR has been merged, remove this patch
-        (
-            "openedx-dockerfile-post-git-checkout",
-            """
-RUN git remote add edly https://github.com/edly-io/edx-platform \
-    && git fetch edly edly/forumv2-sumac \
-    && git merge --allow-unrelated-histories edly/edly/forumv2-sumac""",
-        ),
-        # Enable forum feature
-        (
-            "openedx-common-settings",
-            """# Forum configuration
+tutor_hooks.Filters.ENV_PATCHES.add_item(
+    # Enable forum feature
+    (
+        "openedx-common-settings",
+        """# Forum configuration
 FORUM_SEARCH_BACKEND = "forum.search.meilisearch.MeilisearchBackend"
 FEATURES["ENABLE_DISCUSSION_SERVICE"] = True
 """,
-        ),
-    ]
+    )
 )
 
 # Enable forum v2


### PR DESCRIPTION
Since upstream PR has both been merged (https://github.com/openedx/edx-platform/pull/35671) and cherry picked into sumac.master (https://github.com/openedx/edx-platform/commit/e587a7dfdef0a148c0c3368a1928a89bfecb2401), the env patch is no longer needed.

It is also breaking sandbox build because of a missing ref https://github.com/overhangio/openedx-release-demo/actions/runs/12228105350/job/34105820263
```
#17 [code 5/5] RUN git remote add edly https://github.com/edly-io/edx-platform     && git fetch edly edly/forumv2-sumac     && git merge --allow-unrelated-histories edly/edly/forumv2-sumac
#17 0.347 fatal: couldn't find remote ref edly/forumv2-sumac
```