### PR TITLE
fix: "SCRAM-SHA-1 requires a username" error for mongodb srv config with username

### DIFF
--- a/changelog.d/20241230_144042_kaustav_do_not_set_null_creds.md
+++ b/changelog.d/20241230_144042_kaustav_do_not_set_null_creds.md
@@ -1,0 +1,1 @@
+- [Budfix] Fix crashing of LMS init job due to `FORUM_MONGODB_CLIENT_PARAMETERS` containing username/password with `None` values. (by @kaustavb12)

--- a/tutorforum/plugin.py
+++ b/tutorforum/plugin.py
@@ -30,8 +30,8 @@ FORUM_MONGODB_DATABASE = "cs_comments_service"
 FORUM_MONGODB_CLIENT_PARAMETERS = {
     "host": "{{ MONGODB_HOST }}",
     "port": {{ MONGODB_PORT }},
-    "username": {% if MONGODB_USERNAME %}"{{ MONGODB_USERNAME }}"{% else %}None{% endif %},
-    "password": {% if MONGODB_PASSWORD %}"{{ MONGODB_PASSWORD }}"{% else %}None{% endif %},
+    {% if MONGODB_USERNAME %}"username": "{{ MONGODB_USERNAME }}",{% endif %}
+    {% if MONGODB_PASSWORD %}"password": "{{ MONGODB_PASSWORD }}",{% endif %}
     "ssl": {{ MONGODB_USE_SSL }},
 }
 {}


### PR DESCRIPTION
## Description

Currently we are setting `None` to mongodb username and password parameters in `FORUM_MONGODB_CLIENT_PARAMETERS`.

PyMongo currently throws the following error if the credentials as added to the `host` parameter as a connection string.

```
pymongo.errors.ConfigurationError: SCRAM-SHA-1 requires a username.
```

This PR fixes this issue by omitting the two parameters completely if the corresponding values are not available.


## Other information

Private Ref : [BB-9353](https://tasks.opencraft.com/browse/BB-9353)