### PR TITLE
feat: make FORUM_MONGODB_DATABASE configurable

### DIFF
--- a/tutorforum/plugin.py
+++ b/tutorforum/plugin.py
@@ -12,6 +12,7 @@ if __version_suffix__:
 config = {
     "defaults": {
         "VERSION": __version__,
+        "MONGODB_DATABASE": "cs_comments_service",
     },
 }
 
@@ -26,7 +27,7 @@ tutor_hooks.Filters.ENV_PATCHES.add_item(
 FORUM_SEARCH_BACKEND = "forum.search.meilisearch.MeilisearchBackend"
 FEATURES["ENABLE_DISCUSSION_SERVICE"] = True
 # Forum mongodb configuration, for existing platforms still running mongodb
-FORUM_MONGODB_DATABASE = "cs_comments_service"
+FORUM_MONGODB_DATABASE = "{{ FORUM_MONGODB_DATABASE }}"
 FORUM_MONGODB_CLIENT_PARAMETERS = {
     "host": "{{ MONGODB_HOST }}",
     "port": {{ MONGODB_PORT }},


### PR DESCRIPTION
`FORUM_MONGODB_DATABASE` was configurable previously - [see v18.1.1](https://github.com/overhangio/tutor-forum/blob/664ccdd61f10a5c88ec71b3d1e6e3d1c6891d27e/tutorforum/plugin.py#L22). This is necessary when you have many instances using the same MongoDB deployment.