### PR TITLE
chore: update maintainer information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ To debug the forum application, you are encouraged to mount the ``forum`` reposi
 Troubleshooting
 ---------------
 
-This Tutor plugin is maintained by Ghassan Maslamani (ghassan.maslamani@gmail.com).
+This Tutor plugin is maintained by Abdul-Muqadim (abdul.muqadim@arbisoft.com).
 Community support is available from the official `Open edX forum <https://discuss.openedx.org>`__.
 Do you need help with this plugin? See the `troubleshooting <https://docs.tutor.edly.io/troubleshooting.html>`__ section
 from the Tutor documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ authors = [
   { email = "hello@edly.io" }
 ]
 maintainers = [
-  { name = "ghassan.blog" },
-  { email = "ghassan.maslamani@gmail.com" }
+  { name = "Abdul-Muqadim" },
+  { email = "abdul.muqadim@arbisoft.com" }
 ]
 description = "forum plugin for Tutor"
 readme = { file = "README.rst", content-type = "text/x-rst" }


### PR DESCRIPTION
Changed maintainer details in README.md and pyproject.toml for the Tutor Forum plugin: https://github.com/overhangio/tutor-forum

The previous maintainer is stepping down. I will now take over responsibility for maintenance, addressing issues and queries, and managing future upgrades