### PR TITLE
feat: migrate from pylint/black to ruff

### DIFF
--- a/.hatch_build.py
+++ b/.hatch_build.py
@@ -18,5 +18,5 @@ def load_about() -> dict[str, str]:
     with open(
         os.path.join(HERE, "tutorforum", "__about__.py"), "rt", encoding="utf-8"
     ) as f:
-        exec(f.read(), about)  # pylint: disable=exec-used
+        exec(f.read(), about)
     return about

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,30 @@
 .DEFAULT_GOAL := help
 .PHONY: docs
 SRC_DIRS = ./tutorforum
-BLACK_OPTS = --exclude templates ${SRC_DIRS}
 
-# Warning: These checks are not necessarily run on every PR.
-test: test-lint test-types test-format  # Run some static checks.
+# Warning: These checks are run on every PR.
+test: test-lint test-format test-types test-pythonpackage # Run some static checks.
 
-test-format: ## Run code formatting tests
-	black --check --diff $(BLACK_OPTS)
+test-format: ## Run code formatting tests.
+	ruff format --check --diff $(SRC_DIRS)
 
 test-lint: ## Run code linting tests
-	pylint --errors-only --enable=unused-import,unused-argument --ignore=templates --ignore=docs/_ext ${SRC_DIRS}
+	ruff check ${SRC_DIRS}
 
 test-types: ## Run type checks.
 	mypy --exclude=templates --ignore-missing-imports --implicit-reexport --strict ${SRC_DIRS}
 
-format: ## Format code automatically
-	black $(BLACK_OPTS)
+build-pythonpackage: ## Build the "tutor-forum" python package for upload to pypi
+	python -m build --sdist
 
-isort: ##  Sort imports. This target is not mandatory because the output may be incompatible with black formatting. Provided for convenience purposes.
-	isort --skip=templates ${SRC_DIRS}
+test-pythonpackage: build-pythonpackage ## Test that package can be uploaded to pypi
+	twine check dist/tutor_forum-$(shell make version).tar.gz
+
+format: ## Format code automatically.
+	ruff format ${SRC_DIRS}
+
+fix-lint: ## Fix lint errors automatically
+	ruff check --fix ${SRC_DIRS}
 
 changelog-entry: ## Create a new changelog entry.
 	scriv create
@@ -27,8 +32,11 @@ changelog-entry: ## Create a new changelog entry.
 changelog: ## Collect changelog entries in the CHANGELOG.md file.
 	scriv collect
 
-ESCAPE = 
-help: ## Print this help
+version: ## Print the current tutor-forum version
+	@python -c 'import io, os; about = {}; exec(io.open(os.path.join("tutorforum", "__about__.py"), "rt", encoding="utf-8").read(), about); print(about["__version__"])'
+
+ESCAPE =
+help: ## Print this help.
 	@grep -E '^([a-zA-Z_-]+:.*?## .*|######* .+)$$' Makefile \
 		| sed 's/######* \(.*\)/@               $(ESCAPE)[1;31m\1$(ESCAPE)[0m/g' | tr '@' '\n' \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'

--- a/changelog.d/20250908_122154_abdul.muqadim_migrate_ruff.md
+++ b/changelog.d/20250908_122154_abdul.muqadim_migrate_ruff.md
@@ -1,0 +1,2 @@
+- [Improvement] Migrate from pylint and black to ruff. (by @Abdul-Muqadim-Arbisoft)
+- [Improvement] Test python package distribution build when running make test. (by @Abdul-Muqadim-Arbisoft)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
   "tutor[dev]>=20.0.0,<21.0.0",
-  "pylint",
-  "black"
+  "ruff",
 ]
 
 [project.entry-points."tutor.plugin.v1"]
@@ -68,3 +67,19 @@ exclude = ["tests*"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["tutorforum"]
+
+[tool.ruff]
+exclude = ["templates", "docs/_ext"]
+
+[tool.ruff.lint]
+# E: pycodestyle errors
+# I: isort
+# N: pep8-naming
+select = ["E", "I", "N"]
+
+# F401: unused-import
+# F841: unused-variable
+# W292: missing-newline-at-end-of-file
+extend-select = ["F401", "F841", "W292"]
+
+[tool.ruff.format]

--- a/tutorforum/plugin.py
+++ b/tutorforum/plugin.py
@@ -77,7 +77,7 @@ else:
 
 # Create Mongodb indexes
 ./manage.py lms forum_create_mongodb_indexes
-""",
+""",  # noqa: E501
     )
 )
 


### PR DESCRIPTION
Linked Epic: overhangio/tutor#1251

Some new rules that have been added are:

I: sort imports
N: check for pep8-naming standards
W292: check for missing extra line at EOF

Some of our lines, particularly in config break the 88 character line length limit. For that, we add a # noqa: E501 to let ruff know to ignore the rule for that line

* test: python package distribution build when running make test Pushing to pypi would occasionally fail because of breaking distribution build. We verify the build in the github CI now so that we can mitigate those errors later on.

* fix: install ruff instead of pylint/black as optional dev dependency