### PR TITLE
Chore: drop compatibility with Python 3.9 and ensure compatibility with Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-         python-version: ['3.9', '3.12']
+         python-version: ['3.10', '3.14']
     steps:
       - uses: actions/checkout@v4
       - name: Set up ${{ matrix.python-version }}

--- a/changelog.d/20260415_180501_ali.abbas02_python_version_upgrade.md
+++ b/changelog.d/20260415_180501_ali.abbas02_python_version_upgrade.md
@@ -1,0 +1,1 @@
+- [Improvement] Drop Python 3.9 (end-of-life) support, add 3.13/3.14 classifiers, update CI matrix to 3.10/3.14, and bump `actions/checkout` to v4.

--- a/changelog.d/20260415_180501_ali.abbas02_python_version_upgrade.md
+++ b/changelog.d/20260415_180501_ali.abbas02_python_version_upgrade.md
@@ -1,1 +1,1 @@
-- [Improvement] Drop Python 3.9 (end-of-life) support, add 3.13/3.14 classifiers, update CI matrix to 3.10/3.14, and bump `actions/checkout` to v4. (By @Syed-Ali-Abbas-568)
+- 💥[Improvement] Add Python 3.13 and 3.14 support. Drop Python 3.9 (end-of-life). Update CI matrix from Python 3.9/3.12 to 3.10/3.14. (by @Syed-Ali-Abbas-568)

--- a/changelog.d/20260415_180501_ali.abbas02_python_version_upgrade.md
+++ b/changelog.d/20260415_180501_ali.abbas02_python_version_upgrade.md
@@ -1,1 +1,1 @@
-- [Improvement] Drop Python 3.9 (end-of-life) support, add 3.13/3.14 classifiers, update CI matrix to 3.10/3.14, and bump `actions/checkout` to v4.
+- [Improvement] Drop Python 3.9 (end-of-life) support, add 3.13/3.14 classifiers, update CI matrix to 3.10/3.14, and bump `actions/checkout` to v4. (By @Syed-Ali-Abbas-568)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,18 @@ maintainers = [
 ]
 description = "forum plugin for Tutor"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: GNU Affero General Public License v3",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "tutor>=21.0.0,<22.0.0"


### PR DESCRIPTION
- Bump requires-python from >=3.9 to >=3.10 (Python 3.9 is EOL)
- Add Python 3.13 and 3.14 classifiers to pyproject.toml
- Remove Python 3.9 classifier
- Update CI matrix from ['3.9', '3.12'] to ['3.10', '3.14']


Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>